### PR TITLE
Option to add signed-off-by in commit message

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ runs:
         fi
 
     - name: "Commit changes"
-      if: steps.detect-changes.outputs.changed == 'true' && sign-off-commit == 'true'
+      if: steps.detect-changes.outputs.changed == 'true' && inputs.sign-off-commit == 'true'
       uses: EndBug/add-and-commit@v9
       with:
         commit: --signoff

--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,7 @@ runs:
         push: origin dep/update-pdm-lock --set-upstream --force
 
     - name: "Commit changes"
-      if: steps.detect-changes.outputs.changed == 'true'
+      if: steps.detect-changes.outputs.changed == 'true' && inputs.sign-off-commit == 'false'
       uses: EndBug/add-and-commit@v9
       with:
         message: ${{ inputs.commit-message }}

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: "Whether install PDM plugins before update"
     required: false
     default: "false"
+  sign-off-commit:
+    description: "Whether commit message contains signed-off-by"
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -44,6 +48,15 @@ runs:
         else
           echo "changed=false" >> $GITHUB_OUTPUT
         fi
+
+    - name: "Commit changes"
+      if: steps.detect-changes.outputs.changed == 'true' && sign-off-commit == 'true'
+      uses: EndBug/add-and-commit@v9
+      with:
+        commit: --signoff
+        message: ${{ inputs.commit-message }}
+        new_branch: dep/update-pdm-lock
+        push: origin dep/update-pdm-lock --set-upstream --force
 
     - name: "Commit changes"
       if: steps.detect-changes.outputs.changed == 'true'


### PR DESCRIPTION
Added a boolean true/false to conditionally sign the commit message (required to pass validation by commonly used DCO GitHub App).

See: https://github.com/apps/dco